### PR TITLE
修复cmd/socks启动WaitGroup等待失败问题。

### DIFF
--- a/cmd/socks.go
+++ b/cmd/socks.go
@@ -26,8 +26,8 @@ var socksCmd = &cobra.Command{
 		key := randomString(socks.KeyLength)
 
 		var wg sync.WaitGroup
+		wg.Add(1)
 		go func() {
-			wg.Add(1)
 			defer wg.Done()
 			socks.Serve(lp, sp, key)
 		}()


### PR DESCRIPTION
## 问题
使用SCFProxy进行socks代理时，偶然发现，cmd/socks在执行时，主进程创建WaitGroup并启动一个协程后，可能发生主进程的wg.wait()比协程的wg.add(1)先执行的情况，造成协程跟随主进程提前结束的情况，协程后面的监听服务也未开始执行。

## 修复
将wg.add(1)放在协程外面wg.wait()前执行。