### PR TITLE
Fix the conflict between global sessions & local sessions  in socks/socks.go

### DIFF
--- a/socks/socks.go
+++ b/socks/socks.go
@@ -61,7 +61,7 @@ func listenClient(port string) {
 }
 
 func forward(conn net.Conn) {
-	scfConn := pickConn(sessions)
+	scfConn := pickConn()
 
 	_forward := func(src, dest net.Conn) {
 		defer src.Close()
@@ -74,7 +74,7 @@ func forward(conn net.Conn) {
 
 }
 
-func pickConn(sessions []*yamux.Session) net.Conn {
+func pickConn() net.Conn {
 	for {
 		l := len(sessions)
 		if l == 0 {


### PR DESCRIPTION
# Fix the conflict between global variable sessions in socks/socks.go and local variable sessions in pickConn function of socks/socks.go. 

## 问题

运行时发现会有少数连接无响应问题。使用`--debug`进行跟踪调试发现问题发生在文件`socks/socks.go`里，其中函数`pickConn`的`sessions`是通过传参得到的局部变量，不是真正的全局`sessions`池，所以当调用`pickConn`并传入全局`sessions`后，`pickConn`里的`sessions`就固定在传入时的样子，同时`pickConn`里的无效连接移除不会作用于全局变量`sessions`，只会生效于局部变量`sessions`。这将使`sessions`池中的失效连接并未被实际移除，同时`pickConn`中的局部`sessions`池不会有新增连接的加入（新增操作只作用于全局`sessions`池）导致`pickConn`有大概率发生死循环（传入`sessions`为空数组或者传入的`sessions`里的所有连接都失效时）。长时间运行可能导致更严重的内存泄露。

## 问题表现

`--debug`模式中，一直提示`No scf server connections`。

## 复现例子

```golang
package main

import (
	"fmt"
	"sync"
	"time"

	"golang.org/x/exp/slices"
)

type Test struct {
	t string
}

var sessions []*Test
var ws sync.WaitGroup

func main() {
	ws.Add(1)
	go appendTest()
	ws.Add(1)
	go deleteTest(sessions)
	ws.Wait()
	fmt.Println("In main After deleteTest global sessions =", sessions)
}
func appendTest() {
	defer ws.Done()
	sessions = append(sessions, &Test{t: "a"})
	sessions = append(sessions, &Test{t: "b"})
	sessions = append(sessions, &Test{t: "c"})
	fmt.Println("Append done sessions =", sessions)
}

func deleteTest(sessions []*Test) {
	defer ws.Done()
	for {
		if len(sessions) == 0 {
			fmt.Println("continue")
			time.Sleep(5 * time.Second)
			continue
		}
		fmt.Println("In deleteTest Before delete sessions =", sessions)
		sessions = slices.Delete(sessions, 0, 1)
		fmt.Println("In deleteTest After delete sessions =", sessions)
	}
}
```

## 修复

有几种简单的修复方式，
1、`pickConn`传参时改传全局`sessions`池的地址
2、`pickConn`不传参，函数里直接使用全局`sessions`
3、其他

为了代码的简洁和易读性这里选择第二种方式。